### PR TITLE
Make tokenizer thread safe

### DIFF
--- a/nlp-parent/nlp-tokenizer/pom.xml
+++ b/nlp-parent/nlp-tokenizer/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>vn.hus</groupId>
 	<artifactId>nlp-tokenizer</artifactId>
-	<version>4.1.1</version>
+	<version>4.1.2</version>
 
 	<parent>
 	    <groupId>com.tamedtornado</groupId>
@@ -21,7 +21,7 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>vn.hus</groupId>
 			<artifactId>nlp-utils</artifactId>
@@ -41,6 +41,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>2.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.2</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
@@ -54,8 +66,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/nlp-parent/nlp-tokenizer/src/main/java/me/duydo/vi/Tokenizer.java
+++ b/nlp-parent/nlp-tokenizer/src/main/java/me/duydo/vi/Tokenizer.java
@@ -68,10 +68,12 @@ public class Tokenizer {
         String line = null;
         int column = 1;
         while (true) {
-            if (line == null || line.trim().length() == 0) {
+            if (line == null || line.trim().isEmpty()) {
                 line = reader.readLine();
                 if (line == null) {
                     break;
+                } else if (line.trim().isEmpty()) {
+                    continue;
                 }
             }
             TaggedWord taggedWord = null;
@@ -101,7 +103,7 @@ public class Tokenizer {
             // yes, I know that this "manual" method must be improved by a more general way.
             // But at least, it can fix an error with email addresses at the moment. :-)
             int endIndex = tokenEnd;
-            if (tokenEnd < line.length()) {
+            if (tokenEnd >= 0 && tokenEnd < line.length()) {
                 if (line.charAt(tokenEnd) == '@') {
                     while (endIndex > 0 && line.charAt(endIndex) != ' ') {
                         endIndex--;

--- a/nlp-parent/nlp-tokenizer/src/main/java/me/duydo/vi/Tokenizer.java
+++ b/nlp-parent/nlp-tokenizer/src/main/java/me/duydo/vi/Tokenizer.java
@@ -24,8 +24,6 @@ import java.util.regex.Pattern;
 
 public class Tokenizer {
 
-    private Segmenter segmenter;
-
     private boolean isAmbiguitiesResolved = true;
 
     private ResultMerger resultMerger;
@@ -33,6 +31,8 @@ public class Tokenizer {
     private ResultSplitter resultSplitter;
 
     private final List<LexerRule> rules = new ArrayList<>();
+    private Properties properties;
+    private UnigramResolver unigramModel;
 
     public Tokenizer() {
         init();
@@ -40,12 +40,12 @@ public class Tokenizer {
 
     private void init() {
         try {
-            final Properties properties = new Properties();
+            properties = new Properties();
             properties.load(getClass().getResourceAsStream("/tokenizer.properties"));
             loadLexerRules(properties.getProperty("lexers"));
             resultMerger = new ResultMerger();
             resultSplitter = new ResultSplitter(properties);
-            segmenter = new Segmenter(properties, new UnigramResolver(properties.getProperty("unigramModel")));
+            unigramModel = new UnigramResolver(properties.getProperty("unigramModel"));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -63,6 +63,7 @@ public class Tokenizer {
     }
 
     public List<TaggedWord> tokenize(Reader input) throws IOException {
+        Segmenter segmenter = new Segmenter(properties, unigramModel);
         final List<TaggedWord> result = new ArrayList<>();
         final LineNumberReader reader = new LineNumberReader(input);
         String line = null;


### PR DESCRIPTION
Tokenizer uses `segmenter` to tokenize the input. Unfortunately, segmenter is not thread-safe as it stores its state in a mutable List `result`.

This fix instantiates a new `segmenter` each time tokenizer calls `tokenizer`.