### PR TITLE
instantiate segmenter on tokenize method

### DIFF
--- a/nlp-parent/nlp-tokenizer/src/main/java/me/duydo/vi/Tokenizer.java
+++ b/nlp-parent/nlp-tokenizer/src/main/java/me/duydo/vi/Tokenizer.java
@@ -24,8 +24,6 @@ import java.util.regex.Pattern;
 
 public class Tokenizer {
 
-    private Segmenter segmenter;
-
     private boolean isAmbiguitiesResolved = true;
 
     private ResultMerger resultMerger;
@@ -33,6 +31,8 @@ public class Tokenizer {
     private ResultSplitter resultSplitter;
 
     private final List<LexerRule> rules = new ArrayList<>();
+    private Properties properties;
+    private UnigramResolver unigramModel;
 
     public Tokenizer() {
         init();
@@ -40,12 +40,12 @@ public class Tokenizer {
 
     private void init() {
         try {
-            final Properties properties = new Properties();
+            properties = new Properties();
             properties.load(getClass().getResourceAsStream("/tokenizer.properties"));
             loadLexerRules(properties.getProperty("lexers"));
             resultMerger = new ResultMerger();
             resultSplitter = new ResultSplitter(properties);
-            segmenter = new Segmenter(properties, new UnigramResolver(properties.getProperty("unigramModel")));
+            unigramModel = new UnigramResolver(properties.getProperty("unigramModel"));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -63,6 +63,7 @@ public class Tokenizer {
     }
 
     public List<TaggedWord> tokenize(Reader input) throws IOException {
+        Segmenter segmenter = new Segmenter(properties, unigramModel);
         final List<TaggedWord> result = new ArrayList<>();
         final LineNumberReader reader = new LineNumberReader(input);
         String line = null;


### PR DESCRIPTION
Tokenizer uses segmenter to tokenize the input. Unfortunately, segmenter is not thread-safe as it stores its state in a mutable List result.

This fix instantiates a new segmenter each time tokenizer calls tokenizer.